### PR TITLE
fix: use proper input handling for DatePicker test

### DIFF
--- a/tests/day6/test_datepicker.spec.js
+++ b/tests/day6/test_datepicker.spec.js
@@ -1,4 +1,4 @@
-﻿import { test, expect } from '#fixtures';
+import { test, expect } from '#fixtures';
 
 test('DatePicker - select a future date', async ({ page }) => {
   await page.goto('https://demo.automationtesting.in/Datepicker.html');
@@ -8,12 +8,10 @@ test('DatePicker - select a future date', async ({ page }) => {
   const month = String(future.getMonth() + 1).padStart(2, '0');
   const year = future.getFullYear();
   const value = `${month}/${day}/${year}`;
-  await page.evaluate((v) => {
-    const inputs = Array.from(document.querySelectorAll('input'));
-    let target = inputs.find(i => i && (i.id && i.id.toLowerCase().includes('date')) ) || inputs[0];
-    if (target) target.value = v;
-  }, value);
+  // Use Playwright's fill to set the date and trigger events
+  await page.fill('input[id*="date"]', value);
   await page.waitForTimeout(500);
-  const current = await page.evaluate(() => document.querySelector('input')?.value || '');
+  // Retrieve the value from the same input
+  const current = await page.inputValue('input[id*="date"]');
   expect(current).toContain(String(year));
 });


### PR DESCRIPTION
## 🤖 AI Fix — Issue #181

Closes #181

**Root cause:** Direct DOM value assignment bypasses event dispatch, leading to stale or unregistered value in the component.

**Fix:** The test directly set the input value via page.evaluate, which doesn't trigger the necessary input/change events for the datepicker component, causing the assertion to potentially fail. Replaced the manual DOM manipulation with Playwright's page.fill which correctly fills the field and fires events, and used page.inputValue to retrieve the value from the same input element. This minimal change ensures the test behaves as expected.

**Files:** `tests/day6/test_datepicker.spec.js`

**Run:** https://github.com/shekharapple16-spec/hclplaywrightaspire/actions/runs/23405795182

---
*Auto-generated by WhatsApp QA Bot 🤖*