### PR TITLE
fix: correct input selector for date value verification

### DIFF
--- a/tests/day6/test_datepicker.spec.js
+++ b/tests/day6/test_datepicker.spec.js
@@ -1,4 +1,4 @@
-﻿import { test, expect } from '#fixtures';
+import { test, expect } from '#fixtures';
 
 test('DatePicker - select a future date', async ({ page }) => {
   await page.goto('https://demo.automationtesting.in/Datepicker.html');
@@ -14,6 +14,10 @@ test('DatePicker - select a future date', async ({ page }) => {
     if (target) target.value = v;
   }, value);
   await page.waitForTimeout(500);
-  const current = await page.evaluate(() => document.querySelector('input')?.value || '');
+  const current = await page.evaluate(() => {
+    const inputs = Array.from(document.querySelectorAll('input'));
+    const target = inputs.find(i => i && (i.id && i.id.toLowerCase().includes('date')) ) || inputs[0];
+    return target?.value || '';
+  });
   expect(current).toContain(String(year));
 });


### PR DESCRIPTION
## 🤖 AI Fix — Issue #181

Closes #181

**Root cause:** Using a generic selector (document.querySelector('input')) to read the value after setting it on a specific date input leads to mismatched elements.

**Fix:** The test set the date value on the date input but later retrieved the value from the first generic input element, causing the assertion to potentially read the wrong field. Updated the evaluation to locate the same date input when reading the value, ensuring the test checks the intended element without altering test logic.

**Files:** `tests/day6/test_datepicker.spec.js`

**Run:** https://github.com/shekharapple16-spec/hclplaywrightaspire/actions/runs/23405951541

---
*Auto-generated by WhatsApp QA Bot 🤖*