### PR TITLE
fix: ensure testimonials are loaded before extraction

### DIFF
--- a/tests/day7/healthcare_success_testimonials.spec.js
+++ b/tests/day7/healthcare_success_testimonials.spec.js
@@ -11,6 +11,9 @@ test('Extract testimonials from Healthcare Success and write to file', async ({ 
   try {
     await page.goto('https://healthcaresuccess.com/about/testimonials');
 
+    // Ensure testimonial elements are loaded
+    await page.waitForSelector('.testimonial-slide-text', { state: 'visible' });
+
     // Extract all visible testimonial content
     const testimonials = await page.locator('.testimonial-slide-text').allTextContents();
 
@@ -18,7 +21,7 @@ test('Extract testimonials from Healthcare Success and write to file', async ({ 
     const filePath = path.join(__dirname, 'testimonials.txt');
     fs.writeFileSync(filePath, testimonials.join('\n'));
 
-  console.log(`Testimonials written to ${filePath}`);
+    console.log(`Testimonials written to ${filePath}`);
   } catch (error) {
     console.error(`Test failed: ${error}`);
     throw error; // Re-throw the error to fail the test


### PR DESCRIPTION
## 🤖 AI Fix — Issue #185

Closes #185

**Root cause:** Missing synchronization after page navigation; the selector may not be available yet when .allTextContents() is called.

**Fix:** The test attempted to extract testimonial texts immediately after navigation, which could race with page loading and result in empty data. Adding an explicit wait for the testimonial elements guarantees they are present before extraction, making the test reliable.

**Files:** `tests/day7/healthcare_success_testimonials.spec.js`

**Run:** https://github.com/shekharapple16-spec/hclplaywrightaspire/actions/runs/23448597537

---
*Auto-generated by WhatsApp QA Bot 🤖*