### PR TITLE
fix: correct text selector usage in scroll test

### DIFF
--- a/tests/day6/test_scroll_healthcaresuccess.spec.js
+++ b/tests/day6/test_scroll_healthcaresuccess.spec.js
@@ -1,4 +1,4 @@
-﻿import { test, expect } from '#fixtures';
+import { test, expect } from '#fixtures';
 
 test('Validate vertical scrolling on healthcaresuccess.com', async ({ page }) => {
   // Navigate to the page
@@ -9,11 +9,8 @@ test('Validate vertical scrolling on healthcaresuccess.com', async ({ page }) =>
     window.scrollTo(0, document.body.scrollHeight);
   });
 
-  // Wait for the footer text to be visible (using regex for partial match)
-  await page.waitForSelector('text=/Healthcare Success/', { timeout: 5000 });
-
-  // Verify that the bottom-most content is visible
-  const bottomText = await page.locator('text=/Healthcare Success/').first();
+  // Verify that the footer text is visible using the proper text selector API
+  const bottomText = page.getByText(/Healthcare Success/).first();
   await expect(bottomText).toBeVisible();
 
   // Capture a screenshot after scrolling to confirm visual rendering


### PR DESCRIPTION
## 🤖 AI Fix — Issue #184

Closes #184

**Root cause:** Incorrect use of `page.waitForSelector('text=/Healthcare Success/')` – Playwright does not support regex text selectors with `waitForSelector`, leading to element not being found.

**Fix:** The test used `page.waitForSelector` with a text regex selector, which is not supported by Playwright's selector engine and caused the test to fail. Replaced it with the proper `page.getByText` API and removed the unnecessary wait, ensuring the element is located and asserted correctly with minimal changes.

**Files:** `tests/day6/test_scroll_healthcaresuccess.spec.js`

**Run:** https://github.com/shekharapple16-spec/hclplaywrightaspire/actions/runs/23448596262

---
*Auto-generated by WhatsApp QA Bot 🤖*