### PR TITLE
fix: correct fixtures import path in test2.spec.js

### DIFF
--- a/tests/day3/test2.spec.js
+++ b/tests/day3/test2.spec.js
@@ -15,7 +15,7 @@
 //
 //Click the login button(getByRole())
 // @ts-check
-import { test, expect } from '#fixtures';
+import { test, expect } from '../../fixtures.js';
 test('OrangeHRM Login Validation', async ({ page }) => {
   await page.goto('https://opensource-demo.orangehrmlive.com/web/index.php/auth/login');
   await page.getByPlaceholder('Username').fill('Admin');


### PR DESCRIPTION
## 🤖 AI Fix — Issue #188

Closes #188

**Root cause:** Incorrect import alias (`#fixtures`) used in the test file

**Fix:** The test imported `test` and `expect` using the alias `#fixtures`, which is not configured in the project, causing a module resolution error. Updating the import to a relative path that points to the actual `fixtures.js` file resolves the issue with no other changes needed.

**Files:** `tests/day3/test2.spec.js`

**Run:** https://github.com/shekharapple16-spec/hclplaywrightaspire/actions/runs/23449457703

---
*Auto-generated by WhatsApp QA Bot 🤖*