### PR TITLE
fix: corrected the username selector in the Herokuapp Login Validation test

### DIFF
--- a/tests/day3/test1.spec.js
+++ b/tests/day3/test1.spec.js
@@ -1,9 +1,9 @@
-import { test, expect } from '#fixtures'; // ← uses aiDiagnostics auto fixture
+import { test, expect } from '#fixtures';
 
 test('Herokuapp Login Validation', async ({ page }) => {
   await page.goto('https://the-internet.herokuapp.com/login');
   await page.waitForSelector('#username', { timeout: 10000 });
-  await page.fill('#username123', 'tomsmith'); // intentional bug — wrong selector
+  await page.fill('#username', 'tomsmith');
   await page.fill('#password', 'SuperSecretPassword!');
   await page.getByRole('button', { name: 'Login' }).click();
   await page.waitForLoadState('networkidle');


### PR DESCRIPTION
## 🤖 AI Fix — Attempt #1

**Test:** `Herokuapp Login Validation`
**Root cause:** The test was using an incorrect selector for the username field, causing a timeout error.
**Fix:** The test was attempting to fill in the username field using the selector '#username123', which does not exist in the DOM. The correct selector is '#username'.
**File:** `tests/day3/test1.spec.js`
**Run:** https://github.com/shekharapple16-spec/hclplaywrightaspire/actions/runs/23682648138

---
*Auto-generated by WhatsApp QA Bot 🤖*