### PR TITLE
fix: Test timeout of 30000ms exceeded

### DIFF
--- a/tests/day4/test6.spec.js
+++ b/tests/day4/test6.spec.js
@@ -3,10 +3,10 @@ import { test, expect } from '#fixtures';
 test('Dropdown Validation on QAPLAYGROUND', async ({ page }) => {
   await page.goto('https://www.qaplayground.com/practice/select');
 
-  // await page.waitForSelector('div[role="presentation"]', { state: 'visible' });
-
+  await page.locator('button[dir="ltr"]').nth(2).waitFor({ state: 'visible' });
   await page.locator('button[dir="ltr"]').nth(2).click()
 
+  await page.getByText('India', { exact: true }).waitFor({ state: 'visible' });
   await page.getByText('India', { exact: true }).click()
 
   const selectedText = await page.locator('button[dir="ltr"] span').nth(2).innerText();


### PR DESCRIPTION
## 🤖 AI Fix — Attempt #1

**Test:** `Dropdown Validation on QAPLAYGROUND`
**Root cause:** The test is not waiting for the dropdown to be visible before interacting with it
**Fix:** The test is trying to click on the dropdown and select an option without waiting for it to be visible, resulting in a timeout error
**File:** `tests/day4/test6.spec.js`
**Run:** https://github.com/shekharapple16-spec/hclplaywrightaspire/actions/runs/23682706630

---
*Auto-generated by WhatsApp QA Bot 🤖*